### PR TITLE
output json traces in real-time; massage json output. 

### DIFF
--- a/cmd/traced/main.go
+++ b/cmd/traced/main.go
@@ -78,6 +78,8 @@ func main() {
 		log.Fatal(err)
 	}
 
+	fmt.Printf("listening on: %s\n", host.Network().ListenAddresses())
+
 	tr, err := traced.NewTraceCollector(host, *dir, *jsonTrace)
 	if err != nil {
 		log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/libp2p/go-libp2p-noise v0.1.1
 	github.com/libp2p/go-libp2p-pubsub v0.4.0
 	github.com/libp2p/go-libp2p-tls v0.1.3
+	github.com/multiformats/go-multiaddr v0.3.1
 )


### PR DESCRIPTION
* timestamp from nanoseconds to milliseconds from unix epoch.
* replace base64-encoded peer ID with string representation.
* add the remote IP address of the reporting peer.

Still got to figure out how to transform the peer IDs inside the trace submessages...