### PR TITLE
Elasticsearch support

### DIFF
--- a/cmd/traced/main.go
+++ b/cmd/traced/main.go
@@ -29,6 +29,8 @@ func main() {
 	id := flag.String("id", "identity", "daemon identity file")
 	dir := flag.String("dir", "traced.out", "trace log directory")
 	jsonTrace := flag.String("json", "", "json trace directory")
+	elasticsearchConnectionStr := flag.String("elasticsearch", "", "elasticsearch connection string (disables file logging if sent)")
+	elasticsearchIndex := flag.String("elasticsearch-index", "lp2p-tracer", "elasticsearch index")
 	flag.Parse()
 
 	var privkey crypto.PrivKey
@@ -78,9 +80,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	tr, err := traced.NewTraceCollector(host, *dir, *jsonTrace)
-	if err != nil {
-		log.Fatal(err)
+	var tr *traced.TraceCollector
+	if *elasticsearchConnectionStr != "" {
+		tr, err = traced.NewElasticsearchTraceCollector(host, *elasticsearchConnectionStr, *elasticsearchIndex)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		tr, err = traced.NewFileTraceCollector(host, *dir, *jsonTrace)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	logging.SetLogLevel("traced", "DEBUG")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/libp2p/go-libp2p-pubsub-tracer
 go 1.16
 
 require (
+	github.com/elastic/go-elasticsearch/v7 v7.14.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-log v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70d
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elastic/go-elasticsearch/v7 v7.14.0 h1:extp3jos/rwJn3J+lgbaGlwAgs0TVsIHme00GyNAyX4=
+github.com/elastic/go-elasticsearch/v7 v7.14.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=

--- a/traced/elasticsearch_collector.go
+++ b/traced/elasticsearch_collector.go
@@ -14,6 +14,9 @@ import (
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 )
 
+// NewFileTraceCollector creates a new pubsub traces collector. A collector is a process
+// that listens on a libp2p endpoint, accepts pubsub tracing streams from peers,
+// and sends traces to elasticsearch instance
 func NewElasticsearchTraceCollector(host host.Host, connectionString string, index string) (*TraceCollector, error) {
 	conUrl, err := url.Parse(connectionString)
 

--- a/traced/elasticsearch_collector.go
+++ b/traced/elasticsearch_collector.go
@@ -1,0 +1,91 @@
+package traced
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/elastic/go-elasticsearch/esapi"
+	"github.com/elastic/go-elasticsearch/v7"
+	"github.com/libp2p/go-libp2p-core/host"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+)
+
+func NewElasticsearchTraceCollector(host host.Host, connectionString string, index string) (*TraceCollector, error) {
+	conUrl, err := url.Parse(connectionString)
+
+	username := conUrl.User.Username()
+	password, _ := conUrl.User.Password()
+	cfg := elasticsearch.Config{
+		Addresses: []string{
+			conUrl.Scheme + "://" + conUrl.Host,
+		},
+		Username: username,
+		Password: password,
+	}
+
+	es, err := elasticsearch.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &TraceCollector{
+		host:          host,
+		notifyWriteCh: make(chan struct{}, 1),
+		flushFileCh:   make(chan struct{}, 1),
+		exitCh:        make(chan struct{}, 1),
+		doneCh:        make(chan struct{}, 1),
+	}
+	host.SetStreamHandler(pubsub.RemoteTracerProtoID, c.handleStream)
+
+	go c.collectElasticsearchWorker(es, index)
+
+	return c, nil
+}
+
+// collectToElasticsearchWorker routes collected traces to elasticsearch instance
+func (tc *TraceCollector) collectElasticsearchWorker(es *elasticsearch.Client, index string) {
+	var buf []*pb.TraceEvent
+
+	for {
+		tc.mx.Lock()
+		tmp := tc.buf
+		tc.buf = buf[:0]
+		buf := tmp
+		tc.mx.Unlock()
+
+		for i, evt := range buf {
+			jsonEvt, err := json.Marshal(evt)
+			if err != nil {
+				buf[i] = nil
+				fmt.Printf("Failed marshaling event: %w, err")
+			}
+
+			req := esapi.IndexRequest{
+				Index:   index,
+				Body:    strings.NewReader(string(jsonEvt)),
+				Refresh: "true",
+			}
+
+			res, err := req.Do(context.Background(), es)
+			if err != nil {
+				buf[i] = nil
+				fmt.Printf("Failed sending event to elasticsearch: %w, err")
+				continue
+			}
+
+			res.Body.Close()
+			buf[i] = nil
+		}
+
+		// yield if we're done
+		select {
+		case <-tc.exitCh:
+			return
+		default:
+		}
+	}
+}

--- a/traced/file_collector.go
+++ b/traced/file_collector.go
@@ -1,0 +1,241 @@
+package traced
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	ggio "github.com/gogo/protobuf/io"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/libp2p/go-libp2p-core/host"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+)
+
+// NewFileTraceCollector creates a new pubsub traces collector. A collector is a process
+// that listens on a libp2p endpoint, accepts pubsub tracing streams from peers,
+// and records the incoming data into rotating gzip files.
+// If the json argument is not empty, then every time a new trace is generated, it will be written
+// to this directory in json format for online processing.
+func NewFileTraceCollector(host host.Host, dir, jsonTrace string) (*TraceCollector, error) {
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &TraceCollector{
+		host:          host,
+		dir:           dir,
+		jsonTrace:     jsonTrace,
+		notifyWriteCh: make(chan struct{}, 1),
+		flushFileCh:   make(chan struct{}, 1),
+		exitCh:        make(chan struct{}, 1),
+		doneCh:        make(chan struct{}, 1),
+	}
+
+	host.SetStreamHandler(pubsub.RemoteTracerProtoID, c.handleStream)
+
+	go c.collectFileWorker()
+	go c.monitorWorker()
+
+	return c, nil
+}
+
+// writeFile records incoming traces into a gzipped file, and yields every time
+// a flush is triggered.
+func (tc *TraceCollector) writeFile(out io.WriteCloser) (result error) {
+	var (
+		flush bool
+
+		// buf is an internal buffer that gets swapped with the collector's
+		// buffer on write. This saves allocs, and the slices grow to
+		// accommodate the volume that's being written.
+		buf []*pb.TraceEvent
+
+		gzipW = gzip.NewWriter(out)
+		w     = ggio.NewDelimitedWriter(gzipW)
+	)
+
+	for !flush {
+		select {
+		case <-tc.notifyWriteCh:
+		case <-tc.flushFileCh:
+			flush = true
+		}
+
+		// Swap the buffers. We take the collector's buffer, and replace that
+		// with our local buffer (trimmed to 0-length). On the next loop
+		// iteration, the same will occur, so we're effectively swapping buffers
+		// continuously.
+		tc.mx.Lock()
+		tmp := tc.buf
+		tc.buf = buf[:0]
+		buf = tmp
+		tc.mx.Unlock()
+
+		for i, evt := range buf {
+			err := w.WriteMsg(evt)
+			if err != nil {
+				logger.Errorf("error writing event trace: %s", err)
+				return err
+			}
+
+			buf[i] = nil
+		}
+	}
+
+	logger.Debugf("closing trace log")
+
+	err := gzipW.Close()
+	if err != nil {
+		logger.Errorf("error closing trace log: %s", err)
+		result = multierror.Append(result, err)
+	}
+
+	err = out.Close()
+	if err != nil {
+		logger.Errorf("error closing trace log: %s", err)
+		result = multierror.Append(result, err)
+	}
+
+	return result
+}
+
+// collectWorker is the main worker. It keeps recording traces into the
+// `current` file and rotates the file when it's filled.
+func (tc *TraceCollector) collectFileWorker() {
+	defer close(tc.doneCh)
+
+	current := fmt.Sprintf("%s/current", tc.dir)
+
+	for {
+		out, err := os.OpenFile(current, os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+
+		err = tc.writeFile(out)
+		if err != nil {
+			panic(err)
+		}
+
+		// Rotate the file.
+		base := fmt.Sprintf("trace.%d", time.Now().UnixNano())
+		next := fmt.Sprintf("%s/%s.pb.gz", tc.dir, base)
+		logger.Debugf("move %s -> %s", current, next)
+		err = os.Rename(current, next)
+		if err != nil {
+			panic(err)
+		}
+
+		// Generate the json output if so desired
+		if tc.jsonTrace != "" {
+			tc.writeJsonTrace(next, base)
+		}
+
+		// yield if we're done.
+		select {
+		case <-tc.exitCh:
+			return
+		default:
+		}
+	}
+}
+
+func (tc *TraceCollector) writeJsonTrace(trace, name string) {
+	// open the trace, read it and transcode to json
+	in, err := os.Open(trace)
+	if err != nil {
+		panic(err)
+	}
+	defer in.Close()
+
+	gzipR, err := gzip.NewReader(in)
+	if err != nil {
+		panic(err)
+	}
+	defer gzipR.Close()
+
+	tmpTrace := fmt.Sprintf("/tmp/%s.json", name)
+	out, err := os.OpenFile(tmpTrace, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		panic(err)
+	}
+
+	var evt pb.TraceEvent
+	pbr := ggio.NewDelimitedReader(gzipR, 1<<20)
+	enc := json.NewEncoder(out)
+
+loop:
+	for {
+		evt.Reset()
+
+		switch err = pbr.ReadMsg(&evt); err {
+		case nil:
+			err = enc.Encode(&evt)
+			if err != nil {
+				panic(err)
+			}
+		case io.EOF:
+			break loop
+		default:
+			panic(err)
+		}
+	}
+
+	err = out.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	jsonTrace := fmt.Sprintf("%s/%s.json", tc.jsonTrace, name)
+	err = os.Rename(tmpTrace, jsonTrace)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// monitorWorker watches the current file and triggers closure+rotation based on
+// time and size.
+//
+// TODO (#3): this needs to use select so we can rcv from exitCh and yield.
+func (tc *TraceCollector) monitorWorker() {
+	current := fmt.Sprintf("%s/current", tc.dir)
+
+Outer:
+	for {
+		start := time.Now()
+
+	Inner:
+		for {
+			time.Sleep(time.Minute)
+
+			now := time.Now()
+			if now.After(start.Add(MaxLogTime)) {
+				select {
+				case tc.flushFileCh <- struct{}{}:
+				default:
+				}
+				continue Outer
+			}
+
+			finfo, err := os.Stat(current)
+			if err != nil {
+				logger.Warnf("error stating trace log file: %s", err)
+				continue Inner
+			}
+
+			if finfo.Size() > int64(MaxLogSize) {
+				select {
+				case tc.flushFileCh <- struct{}{}:
+				default:
+				}
+
+				continue Outer
+			}
+		}
+	}
+}

--- a/traced/traced.go
+++ b/traced/traced.go
@@ -2,21 +2,16 @@ package traced
 
 import (
 	"compress/gzip"
-	"encoding/json"
-	"fmt"
 	"io"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 
 	ggio "github.com/gogo/protobuf/io"
-	multierror "github.com/hashicorp/go-multierror"
 	logging "github.com/ipfs/go-log"
 )
 
@@ -44,35 +39,6 @@ type TraceCollector struct {
 	flushFileCh   chan struct{}
 	exitCh        chan struct{}
 	doneCh        chan struct{}
-}
-
-// NewTraceCollector creates a new pubsub traces collector. A collector is a process
-// that listens on a libp2p endpoint, accepts pubsub tracing streams from peers,
-// and records the incoming data into rotating gzip files.
-// If the json argument is not empty, then every time a new trace is generated, it will be written
-// to this directory in json format for online processing.
-func NewTraceCollector(host host.Host, dir, jsonTrace string) (*TraceCollector, error) {
-	err := os.MkdirAll(dir, 0755)
-	if err != nil {
-		return nil, err
-	}
-
-	c := &TraceCollector{
-		host:          host,
-		dir:           dir,
-		jsonTrace:     jsonTrace,
-		notifyWriteCh: make(chan struct{}, 1),
-		flushFileCh:   make(chan struct{}, 1),
-		exitCh:        make(chan struct{}, 1),
-		doneCh:        make(chan struct{}, 1),
-	}
-
-	host.SetStreamHandler(pubsub.RemoteTracerProtoID, c.handleStream)
-
-	go c.collectWorker()
-	go c.monitorWorker()
-
-	return c, nil
 }
 
 // Stop stops the collector.
@@ -124,202 +90,6 @@ func (tc *TraceCollector) handleStream(s network.Stream) {
 		default:
 			logger.Debugf("error reading batch from %s: %s", s.Conn().RemotePeer(), err)
 			return
-		}
-	}
-}
-
-// writeFile records incoming traces into a gzipped file, and yields every time
-// a flush is triggered.
-func (tc *TraceCollector) writeFile(out io.WriteCloser) (result error) {
-	var (
-		flush bool
-
-		// buf is an internal buffer that gets swapped with the collector's
-		// buffer on write. This saves allocs, and the slices grow to
-		// accommodate the volume that's being written.
-		buf []*pb.TraceEvent
-
-		gzipW = gzip.NewWriter(out)
-		w     = ggio.NewDelimitedWriter(gzipW)
-	)
-
-	for !flush {
-		select {
-		case <-tc.notifyWriteCh:
-		case <-tc.flushFileCh:
-			flush = true
-		}
-
-		// Swap the buffers. We take the collector's buffer, and replace that
-		// with our local buffer (trimmed to 0-length). On the next loop
-		// iteration, the same will occur, so we're effectively swapping buffers
-		// continuously.
-		tc.mx.Lock()
-		tmp := tc.buf
-		tc.buf = buf[:0]
-		buf = tmp
-		tc.mx.Unlock()
-
-		for i, evt := range buf {
-			err := w.WriteMsg(evt)
-			if err != nil {
-				logger.Errorf("error writing event trace: %s", err)
-				return err
-			}
-
-			buf[i] = nil
-		}
-	}
-
-	logger.Debugf("closing trace log")
-
-	err := gzipW.Close()
-	if err != nil {
-		logger.Errorf("error closing trace log: %s", err)
-		result = multierror.Append(result, err)
-	}
-
-	err = out.Close()
-	if err != nil {
-		logger.Errorf("error closing trace log: %s", err)
-		result = multierror.Append(result, err)
-	}
-
-	return result
-}
-
-// collectWorker is the main worker. It keeps recording traces into the
-// `current` file and rotates the file when it's filled.
-func (tc *TraceCollector) collectWorker() {
-	defer close(tc.doneCh)
-
-	current := fmt.Sprintf("%s/current", tc.dir)
-
-	for {
-		out, err := os.OpenFile(current, os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-
-		err = tc.writeFile(out)
-		if err != nil {
-			panic(err)
-		}
-
-		// Rotate the file.
-		base := fmt.Sprintf("trace.%d", time.Now().UnixNano())
-		next := fmt.Sprintf("%s/%s.pb.gz", tc.dir, base)
-		logger.Debugf("move %s -> %s", current, next)
-		err = os.Rename(current, next)
-		if err != nil {
-			panic(err)
-		}
-
-		// Generate the json output if so desired
-		if tc.jsonTrace != "" {
-			tc.writeJsonTrace(next, base)
-		}
-
-		// yield if we're done.
-		select {
-		case <-tc.exitCh:
-			return
-		default:
-		}
-	}
-}
-
-func (tc *TraceCollector) writeJsonTrace(trace, name string) {
-	// open the trace, read it and transcode to json
-	in, err := os.Open(trace)
-	if err != nil {
-		panic(err)
-	}
-	defer in.Close()
-
-	gzipR, err := gzip.NewReader(in)
-	if err != nil {
-		panic(err)
-	}
-	defer gzipR.Close()
-
-	tmpTrace := fmt.Sprintf("/tmp/%s.json", name)
-	out, err := os.OpenFile(tmpTrace, os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		panic(err)
-	}
-
-	var evt pb.TraceEvent
-	pbr := ggio.NewDelimitedReader(gzipR, 1<<20)
-	enc := json.NewEncoder(out)
-
-loop:
-	for {
-		evt.Reset()
-
-		switch err = pbr.ReadMsg(&evt); err {
-		case nil:
-			err = enc.Encode(&evt)
-			if err != nil {
-				panic(err)
-			}
-		case io.EOF:
-			break loop
-		default:
-			panic(err)
-		}
-	}
-
-	err = out.Close()
-	if err != nil {
-		panic(err)
-	}
-
-	jsonTrace := fmt.Sprintf("%s/%s.json", tc.jsonTrace, name)
-	err = os.Rename(tmpTrace, jsonTrace)
-	if err != nil {
-		panic(err)
-	}
-}
-
-// monitorWorker watches the current file and triggers closure+rotation based on
-// time and size.
-//
-// TODO (#3): this needs to use select so we can rcv from exitCh and yield.
-func (tc *TraceCollector) monitorWorker() {
-	current := fmt.Sprintf("%s/current", tc.dir)
-
-Outer:
-	for {
-		start := time.Now()
-
-	Inner:
-		for {
-			time.Sleep(time.Minute)
-
-			now := time.Now()
-			if now.After(start.Add(MaxLogTime)) {
-				select {
-				case tc.flushFileCh <- struct{}{}:
-				default:
-				}
-				continue Outer
-			}
-
-			finfo, err := os.Stat(current)
-			if err != nil {
-				logger.Warnf("error stating trace log file: %s", err)
-				continue Inner
-			}
-
-			if finfo.Size() > int64(MaxLogSize) {
-				select {
-				case tc.flushFileCh <- struct{}{}:
-				default:
-				}
-
-				continue Outer
-			}
 		}
 	}
 }


### PR DESCRIPTION
This PR adds:
- the ability to send traces to elasticsearch instead of saving locally to file.
- separates elastic collector and file collector to separate files to make it more readable.

Would have probably been nice to have the ability to track both, but the buffer logic would need a bigger rewrite
so I avoided it.